### PR TITLE
Upload file, Examples, minor touch-up

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,6 +91,18 @@ Usage
     # See the API documentation for which events are available.
     foo.init_websocket(event_handler)
 
+    # To upload a file you will need to pass a `files` dictionary
+    channel_id = foo.api['channels'].get_channel_by_name_and_team_name('team', 'channel')['id']
+    file_id = foo.api['files'].upload_file(
+                channel_id=channel_id
+                files={'files': (filename, open(filename))})['file_infos'][0]['id]
+
+    # track the file id and pass it in `create_post` options, to attach the file
+    foo.api['posts'].create_post(options={
+        'channel_id': channel_id,
+        'message': 'This is the important file',
+        'file_ids': [file_id]})
+
 .. inclusion-marker-end-usage
 
 Available endpoints:

--- a/src/mattermostdriver/client.py
+++ b/src/mattermostdriver/client.py
@@ -1,5 +1,3 @@
-import json
-
 import logging
 import requests
 
@@ -112,7 +110,7 @@ class Client:
 		try:
 			response.raise_for_status()
 		except requests.HTTPError as e:
-			data = json.loads(e.response.text)
+			data = e.response.json()
 			if data['status_code'] == 400:
 				raise InvalidOrMissingParameters(data['message'])
 			elif data['status_code'] == 401:
@@ -126,25 +124,17 @@ class Client:
 			else:
 				raise
 
-		log.debug(json.loads(response.text))
+		log.debug(response.json())
 		return response
 
 	def get(self, endpoint, options=None, params=None):
-		return json.loads(
-			self.make_request('get', endpoint, options=options, params=params).text
-		)
+		return self.make_request('get', endpoint, options=options, params=params).json()
 
 	def post(self, endpoint, options=None, params=None, data=None, files=None):
-		return json.loads(
-			self.make_request('post', endpoint, options=options, params=params, data=data, files=files).text
-		)
+		return self.make_request('post', endpoint, options=options, params=params, data=data, files=files).json()
 
 	def put(self, endpoint, options=None, params=None, data=None):
-		return json.loads(
-			self.make_request('put', endpoint, options=options, params=params, data=data).text
-		)
+		return self.make_request('put', endpoint, options=options, params=params, data=data).json()
 
 	def delete(self, endpoint, options=None, params=None, data=None):
-		return json.loads(
-			self.make_request('delete', endpoint, options=options, params=params, data=data).text
-		)
+		return self.make_request('delete', endpoint, options=options, params=params, data=data).json()

--- a/src/mattermostdriver/client.py
+++ b/src/mattermostdriver/client.py
@@ -84,7 +84,7 @@ class Client:
 			return {}
 		return {"Authorization": "Bearer {token:s}".format(token=self._token)}
 
-	def make_request(self, method, endpoint, options=None, params=None, data=None):
+	def make_request(self, method, endpoint, options=None, params=None, data=None, files=None):
 		if options is None:
 			options = {}
 		if params is None:
@@ -106,7 +106,8 @@ class Client:
 				verify=self._verify,
 				json=options,
 				params=params,
-				data=data
+				data=data,
+				files=files
 			)
 		try:
 			response.raise_for_status()
@@ -133,9 +134,9 @@ class Client:
 			self.make_request('get', endpoint, options=options, params=params).text
 		)
 
-	def post(self, endpoint, options=None, params=None, data=None):
+	def post(self, endpoint, options=None, params=None, data=None, files=None):
 		return json.loads(
-			self.make_request('post', endpoint, options=options, params=params, data=data).text
+			self.make_request('post', endpoint, options=options, params=params, data=data, files=files).text
 		)
 
 	def put(self, endpoint, options=None, params=None, data=None):

--- a/src/mattermostdriver/endpoints/files.py
+++ b/src/mattermostdriver/endpoints/files.py
@@ -4,10 +4,11 @@ from .base import Base
 class Files(Base):
 	endpoint = '/files'
 
-	def upload_file(self, data):
+	def upload_file(self, channel_id, files):
 		return self.client.post(
 			self.endpoint,
-			data=data
+			data={'channel_id': channel_id},
+			files=files
 		)
 
 	def get_file(self, file_id):


### PR DESCRIPTION
In order for `requests` to format the request data as `multipart/form-data`, the `files` parameter has to be used. The parameter has been implemented in `Client` `make_request` and `post` and in the `Files` endpoint, where the parameter `data` has been replaced by `channel_id` and `files`.

I provided an example of how to upload a file and mention it in a post.

I also replaced usage of `json` in `clients.py`, since it is easier available from `requests` response object.