### PR TITLE
Handle non-JSON responses

### DIFF
--- a/src/mattermostdriver/client.py
+++ b/src/mattermostdriver/client.py
@@ -11,6 +11,7 @@ from .exceptions import (
 	NoAccessTokenProvided,
 	NotEnoughPermissions,
 	ResourceNotFound,
+	MethodNotAllowed,
 	ContentTooLarge,
 	FeatureDisabled
 )
@@ -155,6 +156,8 @@ class Client:
 				raise NotEnoughPermissions(message)
 			elif e.response.status_code == 404:
 				raise ResourceNotFound(message)
+			elif e.response.status_code == 405:
+				raise MethodNotAllowed(message)
 			elif e.response.status_code == 413:
 				raise ContentTooLarge(message)
 			elif e.response.status_code == 501:

--- a/src/mattermostdriver/client.py
+++ b/src/mattermostdriver/client.py
@@ -140,20 +140,25 @@ class Client:
 		try:
 			response.raise_for_status()
 		except requests.HTTPError as e:
-			data = e.response.json()
-			log.error(data['message'])
-			if data['status_code'] == 400:
-				raise InvalidOrMissingParameters(data['message'])
-			elif data['status_code'] == 401:
-				raise NoAccessTokenProvided(data['message'])
-			elif data['status_code'] == 403:
-				raise NotEnoughPermissions(data['message'])
-			elif data['status_code'] == 404:
-				raise ResourceNotFound(data['message'])
-			elif data['status_code'] == 413:
-				raise ContentTooLarge(data['message'])
-			elif data['status_code'] == 501:
-				raise FeatureDisabled(data['message'])
+			try:
+				data = e.response.json()
+				message = data.get('message', data)
+			except ValueError:
+				log.debug('Could not convert response to json')
+				message = response.text
+			log.error(message)
+			if e.response.status_code == 400:
+				raise InvalidOrMissingParameters(message)
+			elif e.response.status_code == 401:
+				raise NoAccessTokenProvided(message)
+			elif e.response.status_code == 403:
+				raise NotEnoughPermissions(message)
+			elif e.response.status_code == 404:
+				raise ResourceNotFound(message)
+			elif e.response.status_code == 413:
+				raise ContentTooLarge(message)
+			elif e.response.status_code == 501:
+				raise FeatureDisabled(message)
 			else:
 				raise
 

--- a/src/mattermostdriver/exceptions.py
+++ b/src/mattermostdriver/exceptions.py
@@ -29,6 +29,13 @@ class ResourceNotFound(HTTPError):
 	"""
 
 
+class MethodNotAllowed(HTTPError):
+	"""
+	Raised when mattermost returns a
+	405 Method Not Allowed
+	"""
+
+
 class ContentTooLarge(HTTPError):
 	"""
 	Raised when mattermost returns a


### PR DESCRIPTION
I guess fixes #31.

When that happens fallback to text.

I also added the `MethodNotAllowed` exception, which is returned with an empty body, for example on a `POST` with a wrong `basepath` (`POST /api/vv4`) but maybe we want to limit ourselves to Mattermost JSON errors (not all HTTP)?.