### PR TITLE
Fix logout by loging out before cleaning up

### DIFF
--- a/src/mattermostdriver/driver.py
+++ b/src/mattermostdriver/driver.py
@@ -183,11 +183,12 @@ class Driver:
 
 		:return: The JSON response from the server
 		"""
+		result = self.users.logout_user()
 		self.client.token = ''
 		self.client.userid = ''
 		self.client.username = ''
 		self.client.cookies = None
-		return self.users.logout_user()
+		return result
 
 	@property
 	def api(self):


### PR DESCRIPTION
We still need to use the temporary token generated by a login/password authentication to actually logout. So I moved the clean up after the call to `logout_user()`