### PR TITLE
Add missing status, roles and commands properties

### DIFF
--- a/src/mattermostdriver/driver.py
+++ b/src/mattermostdriver/driver.py
@@ -364,3 +364,30 @@ class Driver:
 		:return: Instance of :class:`~endpoints.data_retention.DataRetention`
 		"""
 		return DataRetention(self.client)
+
+	@property
+	def status(self):
+		"""
+		Api endpoint for status
+
+		:return: Instance of :class:`~endpoints.status.Status`
+		"""
+		return Status(self.client)
+
+	@property
+	def commands(self):
+		"""
+		Api endpoint for commands
+
+		:return: Instance of :class:`~endpoints.commands.Commands`
+		"""
+		return Commands(self.client)
+	
+	@property
+	def roles(self):
+		"""
+		Api endpoint for roles
+
+		:return: Instance of :class:`~endpoints.roles.Roles`
+		"""
+		return Roles(self.client)


### PR DESCRIPTION
While attempting to modify a user's status I noticed the property for accessing the endpoint didn't exist on the `Driver` class but did exist under the deprecated api property. I'm also adding the roles/commands properties too while I'm here so the properties the `Driver` class should now be in sync with what's available in the deprecated api property.