### PR TITLE
added ','  to make json valid

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,7 +67,7 @@ Usage
         'port': 8065,
         'basepath': '/api/v4',
         'verify': True,
-        'mfa_token': 'YourMFAToken'
+        'mfa_token': 'YourMFAToken',
 
         """
         If for some reasons you get regular timeouts after a while, try to decrease


### PR DESCRIPTION
missing ',' at line 70, which mage the example code invalid