### PR TITLE
fix to use token from .netrc

### DIFF
--- a/docs/mmDriverTokenAuthExample.py
+++ b/docs/mmDriverTokenAuthExample.py
@@ -1,0 +1,95 @@
+
+# A simple example to retrieve all users for a team while using a _token_ 
+# from the .netrc file instead of a password (as requests assumes by default)
+
+import logging 
+import requests
+import netrc
+
+from mattermostdriver import Driver
+
+logging.basicConfig( format='%(levelname)s - %(name)s - %(asctime)s - %(message)s' )
+logger = logging.getLogger( 'MattermostManager' )
+logger.setLevel( logging.INFO )
+
+# requests overrides the simple authentication token header if it finds the entry in 
+# the ~/.netrc file. Since we want to use ~/.netrc to retrieve the _token_, we need
+# to provide our own Authenticator class:
+
+class TokenAuth( requests.auth.AuthBase ) :
+    def __call__( self, r ) :
+        # Implement my authentication
+        mmHost = 'mattermost.host.in.netrc'
+        (login, account, password) = netrc.netrc().authenticators( mmHost )
+        r.headers[ 'Authorization' ] = "Bearer %s" % password
+        return r
+
+
+class MattermostManager( object ) :
+
+    def __init__( self ) :
+
+        # Get the _token_ (as "password") from the ~/.netrc file.
+        # the corresponding line in the file should look like:
+        # <mattermost.host.in.netrc> foo foo <long-string-of-token>
+        # The "login" and "account" (both set to "foo" in the example are ignored)
+        
+        mmHost = 'mattermost.host.in.netrc'
+        (login, account, password) = netrc.netrc().authenticators( mmHost )
+        logger.debug( "Going to set up driver for connection to %s " % (mmHost,) )
+
+        self.mmDriver = Driver( options={
+            'url'    : mmHost,
+            'scheme' : 'https',
+            'port'   : 443,
+            'auth'   : TokenAuth, # use the new Authenticator class defined above
+        } )
+
+        self.mmDriver.users.get_user( user_id='me' )
+
+    def getTeamMembers( self, teamName ) :
+
+        # for restricted teams, we need to get the ID first, and
+        # for this, we need to have the "name" (as in the URL), not
+        # the "display name", as shown in the GUIs:
+
+        team0 = self.mmDriver.teams.get_team_by_name( teamName )
+        logger.debug( 'team by name %s : %s' % (teamName, team0) )
+        teamId = team0[ 'id' ]
+
+        team = self.mmDriver.teams.check_team_exists( teamName )
+        logger.debug( 'team %s - exists: %s' % (teamName, team[ 'exists' ]) )
+        if not team[ 'exists' ] :
+            logger.error( 'no team with name %s found' % teamName )
+            return
+
+        logger.debug( 'found team %s: %s' % (teamName, self.mmDriver.teams.get_team( teamId )) )
+
+        users = self._getAllUsersForTeam( teamId )
+        logger.debug( 'found %s users for team "%s"' % (len( users ), teamName) )
+
+        return users
+
+    def _getAllUsersForTeam( self, teamId ) :
+
+        # get all users for a team
+        # with the max of 200 per page, we need to iterate a bit over the pages
+
+        users = [ ]
+        pgNo = 0
+        teamUsers = self.mmDriver.users.get_users( params={ 'in_team'  : teamId,
+                                                            'page'     : str( pgNo ),
+                                                            'per_page' : 200,
+                                                            } )
+        while teamUsers :
+            users += teamUsers
+            pgNo += 1
+            teamUsers = self.mmDriver.users.get_users( params={ 'in_team'  : teamId,
+                                                                'per_page' : 200,
+                                                                'page'     : str( pgNo ),
+                                                                } )
+        return users
+
+if __name__ == '__main__' :
+    mmM = MattermostManager()
+    mmM.getTeamMembers( 'myTeam' )

--- a/src/mattermostdriver/client.py
+++ b/src/mattermostdriver/client.py
@@ -32,6 +32,7 @@ class Client:
 		self._basepath = options['basepath']
 		self._port = options['port']
 		self._verify = options['verify']
+		self._auth = options['auth']
 		if options['debug']:
 			self.activate_verbose_logging()
 
@@ -107,6 +108,7 @@ class Client:
 		self._token = t
 
 	def auth_header(self):
+		if self._auth: return None
 		if self._token == '':
 			return {}
 		return {"Authorization": "Bearer {token:s}".format(token=self._token)}
@@ -139,6 +141,7 @@ class Client:
 		response = request(
 				url + endpoint,
 				headers=self.auth_header(),
+				auth = self._auth(),
 				verify=self._verify,
 				json=options,
 				params=params,

--- a/src/mattermostdriver/driver.py
+++ b/src/mattermostdriver/driver.py
@@ -48,6 +48,7 @@ class Driver:
 		'password': None,
 		'token': None,
 		'mfa_token': None,
+		'auth': None,
 		'debug': False
 	}
 	"""
@@ -68,6 +69,7 @@ class Driver:
 		- timeout (30)
 		- request_timeout (None)
 		- mfa_token (None)
+		- auth (None)
 		- debug (False)
 
 	Should not be changed


### PR DESCRIPTION
I want to use .netrc to get an access token instead of a login/pwd combination. At present, when mmdriver finds the host in .netrc, it assumes basic authentication with login/pwd from there. 

This PR modifies the behaviour and allows the user to pass  in an Auth object which can be used in a more flexible way, e.g. setting  up the Authorization header with a "Bearer <token>" value. 