### PR TITLE
Support python 3.8

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ The repository will try to keep up with the master of https://github.com/matterm
 
 If something changes, it is most likely to change because the official mattermost api changed.
 
-Python 3.4 or later is required.
+Python 3.5 or later is required.
 
 Installation
 ------------

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
 		'Programming Language :: Python :: 3.5',
 		'Programming Language :: Python :: 3.6',
 		'Programming Language :: Python :: 3.7',
+		'Programming Language :: Python :: 3.8',
 	],
 	package_dir={'': 'src'},
 	packages=find_packages('src'),

--- a/setup.py
+++ b/setup.py
@@ -2,18 +2,12 @@
 # -*- coding: utf-8 -*-
 
 import os.path
-import sys
 
 from setuptools import setup, find_packages
 
 full_version = ''
 
 root_dir = os.path.abspath(os.path.dirname(__file__))
-
-py_version = sys.version_info[:2]
-
-if py_version < (3, 4):
-	raise Exception("python-mattermost-driver requires Python >= 3.4.")
 
 readme_file = os.path.join(root_dir, 'README.rst')
 with open(readme_file, encoding='utf-8') as f:
@@ -39,13 +33,13 @@ setup(
 		'Intended Audience :: Developers',
 		'Programming Language :: Python',
 		'Programming Language :: Python :: 3',
-		'Programming Language :: Python :: 3.4',
 		'Programming Language :: Python :: 3.5',
 		'Programming Language :: Python :: 3.6',
 		'Programming Language :: Python :: 3.7',
 	],
 	package_dir={'': 'src'},
 	packages=find_packages('src'),
+	python_requires=">=3.5",
 	install_requires=[
 		'websockets>=6',
 		'requests>=2.19'

--- a/src/mattermostdriver/driver.py
+++ b/src/mattermostdriver/driver.py
@@ -129,8 +129,7 @@ class Driver:
 
 		.. code:: python
 
-			@asyncio.coroutine
-			def my_event_handler(message):
+			async def my_event_handler(message):
 				print(message)
 
 
@@ -386,7 +385,7 @@ class Driver:
 		:return: Instance of :class:`~endpoints.commands.Commands`
 		"""
 		return Commands(self.client)
-	
+
 	@property
 	def roles(self):
 		"""


### PR DESCRIPTION
* Drop Python 3.4 support

  Python 3.4 reached EOL on March 18, 2019:
  https://python.org/downloads/release/python-3410

* Support Python 3.8

  * Python 3.8.0 has been released on October 14, 2019
    https://python.org/downloads/release/python-380
  * Fix `@coroutine` deprecation warnings

    ```
    DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
    ```

    https://docs.python.org/3.8/library/asyncio-task.html#asyncio.coroutine
    https://docs.python.org/3.8/reference/compound_stmts.html#coroutine-function-definition

Note: Although everything loads perfectly, I have not truly tested the websocket part, someone else will have to confirm that it still works as intended.

Closes #51