### PR TITLE
Add `Driver.disconnect` function

### DIFF
--- a/src/mattermostdriver/driver.py
+++ b/src/mattermostdriver/driver.py
@@ -147,6 +147,10 @@ class Driver:
 		loop = asyncio.get_event_loop()
 		loop.run_until_complete(self.websocket.connect(event_handler))
 		return loop
+	
+	def disconnect(self):
+		"""Disconnects the driver from the server, stopping the websocket event loop."""
+		self.websocket.disconnect()
 
 	def login(self):
 		"""

--- a/src/mattermostdriver/driver.py
+++ b/src/mattermostdriver/driver.py
@@ -147,7 +147,7 @@ class Driver:
 		loop = asyncio.get_event_loop()
 		loop.run_until_complete(self.websocket.connect(event_handler))
 		return loop
-	
+
 	def disconnect(self):
 		"""Disconnects the driver from the server, stopping the websocket event loop."""
 		self.websocket.disconnect()

--- a/src/mattermostdriver/driver.py
+++ b/src/mattermostdriver/driver.py
@@ -422,4 +422,3 @@ class Driver:
 		:return: Instance of :class:`~endpoints.integration_actions.IntegrationActions`
 		"""
 		return IntegrationActions(self.client)
-

--- a/src/mattermostdriver/websocket.py
+++ b/src/mattermostdriver/websocket.py
@@ -68,7 +68,7 @@ class Websocket:
 				await websocket.pong()
 				log.debug("Sending heartbeat...")
 				continue
-				
+
 	def disconnect(self):
 		"""Sets `self._alive` to False so the loop in `self._start_loop` will finish."""
 		log.info("Disconnecting websocket")

--- a/src/mattermostdriver/websocket.py
+++ b/src/mattermostdriver/websocket.py
@@ -14,6 +14,7 @@ class Websocket:
 		if options['debug']:
 			log.setLevel(logging.DEBUG)
 		self._token = token
+		self._alive = False
 
 	async def connect(self, event_handler):
 		"""
@@ -56,7 +57,8 @@ class Websocket:
 		forcing us to reconnect.
 		"""
 		log.debug('Starting websocket loop')
-		while True:
+		self._alive = True
+		while self._alive:
 			try:
 				await asyncio.wait_for(
 					self._wait_for_message(websocket, event_handler),
@@ -66,6 +68,11 @@ class Websocket:
 				await websocket.pong()
 				log.debug("Sending heartbeat...")
 				continue
+				
+	def disconnect(self):
+		"""Sets `self._alive` to False so the loop in `self._start_loop` will finish."""
+		log.debug("Stopping websocket loop")
+		self._alive = False
 
 	async def _authenticate_websocket(self, websocket, event_handler):
 		"""

--- a/src/mattermostdriver/websocket.py
+++ b/src/mattermostdriver/websocket.py
@@ -71,7 +71,7 @@ class Websocket:
 				
 	def disconnect(self):
 		"""Sets `self._alive` to False so the loop in `self._start_loop` will finish."""
-		log.debug("Stopping websocket loop")
+		log.info("Disconnecting websocket")
 		self._alive = False
 
 	async def _authenticate_websocket(self, websocket, event_handler):


### PR DESCRIPTION
Since `Driver.init_websocket` starts an infinite loop, there is currently no way to cleanly shutdown the driver. This PR adds a `self._alive` flag that can be toggled with a `disconnect` function to break out of the event loop.