### PR TITLE
chore: Bump version to 7.2.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,22 @@
+7.2.0
+''''''
+Requirement changes
+ - websocket bumped from 6.0 to 8.1
+ - requests bumped from 2.20.0 to 2.25.1
+
+Added
+ - Add Driver.disconnect function #80
+ - Raise errors from None to reduce traceback noise #69
+
+Fixes
+ - Correct url for role by name #78
+ - Add oldest unread endpoint #76
+
+Documentation:
+ - Improve documentation about verify #64
+
+Thanks a lot to @jneeven for his contribution!
+
 7.1.0
 '''''
 Added endpoints

--- a/setup.py
+++ b/setup.py
@@ -37,12 +37,13 @@ setup(
 		'Programming Language :: Python :: 3.6',
 		'Programming Language :: Python :: 3.7',
 		'Programming Language :: Python :: 3.8',
+		'Programming Language :: Python :: 3.9',
 	],
 	package_dir={'': 'src'},
 	packages=find_packages('src'),
 	python_requires=">=3.5",
 	install_requires=[
-		'websockets>=6',
-		'requests>=2.19'
+		'websockets>=8',
+		'requests>=2.25'
 	],
 )

--- a/src/mattermostdriver/version.py
+++ b/src/mattermostdriver/version.py
@@ -1,3 +1,3 @@
 # pylint: disable=invalid-name
-full_version = '7.1.0'
+full_version = '7.2.0'
 short_version = '.'.join(full_version.split('.', 2)[:2])


### PR DESCRIPTION
Requirement changes
 - websocket bumped from 6.0 to 8.1
 - requests bumped from 2.20.0 to 2.25.1

Added
 - Add Driver.disconnect function #80
 - Raise errors from None to reduce traceback noise #69

Fixes
 - Correct url for role by name #78
 - Add oldest unread endpoint #76

Documentation:
 - Improve documentation about verify #64

Thanks a lot to @jneeven for his contribution!