### PR TITLE
Re-establish websocket after connectivity loss

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,6 +97,22 @@ Usage
         'request_timeout': None,
 
         """
+        To keep the websocket connection alive even if it gets disconnected for some reason you 
+        can set the  keepalive option to True. The keepalive_delay defines how long to wait in seconds
+        before attempting to reconnect the websocket. 
+        """
+        'keepalive': False,
+        'keepalive_delay': 5,
+
+        """
+        This option allows you to provide additional keyword arguments when calling websockets.connect()
+        By default it is None, meaning we will not add any additional arguments. An example of an 
+        additional argument you can pass is one used to  disable the client side pings:
+        'websocket_kw_args': {"ping_interval": None},
+        """
+        'websocket_kw_args': None
+
+        """
         Setting debug to True, will activate a very verbose logging.
         This also activates the logging for the requests package,
         so you can see every request you send.

--- a/src/mattermostdriver/driver.py
+++ b/src/mattermostdriver/driver.py
@@ -54,7 +54,7 @@ class Driver:
 		'auth': None,
 		'keepalive': False,
 		'keepalive_delay': 5,
-		'connect_kw_args': None,
+		'websocket_kw_args': None,
 		'debug': False
 	}
 	"""

--- a/src/mattermostdriver/driver.py
+++ b/src/mattermostdriver/driver.py
@@ -52,6 +52,9 @@ class Driver:
 		'token': None,
 		'mfa_token': None,
 		'auth': None,
+		'keepalive': False,
+		'keepalive_delay': 5,
+		'connect_kw_args': None,
 		'debug': False
 	}
 	"""

--- a/src/mattermostdriver/websocket.py
+++ b/src/mattermostdriver/websocket.py
@@ -45,8 +45,8 @@ class Websocket:
 		while True:
 			try:
 				kw_args = {}
-				if self.options['connect_kw_args'] is not None:
-					kw_args = self.options['connect_kw_args']
+				if self.options['websocket_kw_args'] is not None:
+					kw_args = self.options['websocket_kw_args']
 				websocket = await websockets.connect(
 					url,
 					ssl=context,
@@ -57,11 +57,10 @@ class Websocket:
 					try:
 						await self._start_loop(websocket, event_handler)
 					except websockets.ConnectionClosedError:
-						self.disconnect()
 						break
-				if not self.options['keepalive']: break
-			except Exception as e:
-				log.debug(f"Failed to establish websocket connection: {e}")
+				if (not self.options['keepalive']) or (not self._alive) : break
+			except WebSocketException as e:
+				log.warning(f"Failed to establish websocket connection: {e}")
 				await asyncio.sleep(self.options['keepalive_delay'])
 
 	async def _start_loop(self, websocket, event_handler):

--- a/src/mattermostdriver/websocket.py
+++ b/src/mattermostdriver/websocket.py
@@ -55,7 +55,7 @@ class Websocket:
 					except websockets.ConnectionClosedError:
 						self.disconnect()
 						break
-			except (websockets.ConnectionClosedError, ConnectionRefusedError) as e:
+			except Exception as e:
 				log.debug(f"Failed to establish websocket connection: {e}")
 				await asyncio.sleep(self.options['timeout'])
 

--- a/src/mattermostdriver/websocket.py
+++ b/src/mattermostdriver/websocket.py
@@ -44,9 +44,13 @@ class Websocket:
 
 		while True:
 			try:
+				kw_args = {}
+				if self.options['connect_kw_args'] is not None:
+					kw_args = self.options['connect_kw_args']
 				websocket = await websockets.connect(
 					url,
 					ssl=context,
+					**kw_args,
 				)
 				await self._authenticate_websocket(websocket, event_handler)
 				while True:
@@ -55,9 +59,10 @@ class Websocket:
 					except websockets.ConnectionClosedError:
 						self.disconnect()
 						break
+				if not self.options['keepalive']: break
 			except Exception as e:
 				log.debug(f"Failed to establish websocket connection: {e}")
-				await asyncio.sleep(self.options['timeout'])
+				await asyncio.sleep(self.options['keepalive_delay'])
 
 	async def _start_loop(self, websocket, event_handler):
 		"""

--- a/src/mattermostdriver/websocket.py
+++ b/src/mattermostdriver/websocket.py
@@ -58,8 +58,9 @@ class Websocket:
 						await self._start_loop(websocket, event_handler)
 					except websockets.ConnectionClosedError:
 						break
-				if (not self.options['keepalive']) or (not self._alive) : break
-			except WebSocketException as e:
+				if (not self.options['keepalive']) or (not self._alive):
+					break
+			except Exception as e:
 				log.warning(f"Failed to establish websocket connection: {e}")
 				await asyncio.sleep(self.options['keepalive_delay'])
 


### PR DESCRIPTION
When connectivity to the Mattermost server is lost and restored at a later time, the driver fails to re-establish a websocket connection, usually raising a `ConnectionClosedError` exception. This PR resolves that issue with a change to `Websocket.connect()` so that it will continually attempt to re-establish a websocket connection. 

Update: I have merged a PR from @attzonko that makes this optional (default off), and adds a new option for the retry interval.