### PR TITLE
Drop Python 3.5 support explicitly

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.5, 3.6, 3.7]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v1

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ The repository will try to keep up with the master of https://github.com/matterm
 
 If something changes, it is most likely to change because the official mattermost api changed.
 
-Python 3.5 or later is required.
+Python 3.6 or later is required.
 
 Installation
 ------------
@@ -97,16 +97,16 @@ Usage
         'request_timeout': None,
 
         """
-        To keep the websocket connection alive even if it gets disconnected for some reason you 
+        To keep the websocket connection alive even if it gets disconnected for some reason you
         can set the  keepalive option to True. The keepalive_delay defines how long to wait in seconds
-        before attempting to reconnect the websocket. 
+        before attempting to reconnect the websocket.
         """
         'keepalive': False,
         'keepalive_delay': 5,
 
         """
         This option allows you to provide additional keyword arguments when calling websockets.connect()
-        By default it is None, meaning we will not add any additional arguments. An example of an 
+        By default it is None, meaning we will not add any additional arguments. An example of an
         additional argument you can pass is one used to  disable the client side pings:
         'websocket_kw_args': {"ping_interval": None},
         """

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ setup(
 		'Intended Audience :: Developers',
 		'Programming Language :: Python',
 		'Programming Language :: Python :: 3',
-		'Programming Language :: Python :: 3.5',
 		'Programming Language :: Python :: 3.6',
 		'Programming Language :: Python :: 3.7',
 		'Programming Language :: Python :: 3.8',
@@ -41,7 +40,7 @@ setup(
 	],
 	package_dir={'': 'src'},
 	packages=find_packages('src'),
-	python_requires=">=3.5",
+	python_requires=">=3.6",
 	install_requires=[
 		'websockets>=8',
 		'requests>=2.25'


### PR DESCRIPTION
Release 7.2.0 contained a breaking change when it upgraded `websocket` to 8+, which dropped support Python 3.5:
https://websockets.readthedocs.io/en/stable/project/changelog.html#id19

Python 3.5 has also reached EOL in September 2020:
https://www.python.org/dev/peps/pep-0478/