### PR TITLE
Move to httpx over requests to provide a 100% async driver. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,7 @@ com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties
 fabric.properties
+
+# vscode ide
+*.code-workspace
+.vscode

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-requests==2.25.1
+httpx>=0.20.0<1.0.0
 websockets==9.1
 sphinx-rtd-theme==0.4.1

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,6 @@ setup(
 	python_requires=">=3.5",
 	install_requires=[
 		'websockets>=8',
-		'requests>=2.25'
+		'httpx>=0.20.0<1.0.0',
 	],
 )

--- a/src/mattermostdriver/__init__.py
+++ b/src/mattermostdriver/__init__.py
@@ -1,4 +1,4 @@
-__all__ = ['driver', 'client', 'websocket']
+__all__ = ['AsyncClient', 'Driver', 'Client', 'Websocket']
 from .driver import Driver
-from .client import Client
+from .client import Client, AsyncClient
 from .websocket import Websocket

--- a/src/mattermostdriver/__init__.py
+++ b/src/mattermostdriver/__init__.py
@@ -1,4 +1,4 @@
-__all__ = ['AsyncClient', 'Driver', 'Client', 'Websocket']
-from .driver import Driver
+__all__ = ['AsyncClient', 'AsyncDriver', 'Client', 'Driver', 'Websocket']
+from .driver import Driver, AsyncDriver
 from .client import Client, AsyncClient
 from .websocket import Websocket

--- a/src/mattermostdriver/driver.py
+++ b/src/mattermostdriver/driver.py
@@ -314,6 +314,13 @@ class BaseDriver:
 class Driver(BaseDriver):
 	def __init__(self, options=None, client_cls=Client):
 		super().__init__(options, client_cls)
+
+	def __enter__(self):
+		self.client.__enter__()		
+		return self
+
+	def __exit__(self, *exc_info):
+		return self.client.__exit__(*exc_info)
 	
 	def init_websocket(self, event_handler, websocket_cls=Websocket):
 		"""
@@ -397,6 +404,13 @@ class Driver(BaseDriver):
 class AsyncDriver(BaseDriver):
 	def __init__(self, options=None, client_cls=AsyncClient):
 		super().__init__(options, client_cls)
+
+	async def __aenter__(self):
+		await self.client.__aenter__()		
+		return self
+
+	async def __aexit__(self, *exc_info):
+		return await self.client.__aexit__(*exc_info)
 
 	def init_websocket(self, event_handler, websocket_cls=Websocket):
 		"""

--- a/src/mattermostdriver/driver.py
+++ b/src/mattermostdriver/driver.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import warnings
 
-from .client import Client
+from .client import AsyncClient, Client
 from .websocket import Websocket
 from .endpoints.brand import Brand
 from .endpoints.channels import Channels
@@ -33,7 +33,7 @@ log = logging.getLogger('mattermostdriver.api')
 log.setLevel(logging.INFO)
 
 
-class Driver:
+class BaseDriver:
 	"""
 	Contains the client, api and provides you with functions for
 	login, logout and initializing a websocket connection.
@@ -55,7 +55,8 @@ class Driver:
 		'keepalive': False,
 		'keepalive_delay': 5,
 		'websocket_kw_args': None,
-		'debug': False
+		'debug': False,
+		'http2': False
 	}
 	"""
 	Required options
@@ -82,142 +83,24 @@ class Driver:
 		- basepath ('/api/v4') - unlikely this would do any good
 	"""
 
-	def __init__(self, options=None, client_cls=Client):
+	def __init__(self, options, client_cls):
 		"""
 		:param options: A dict with the values from `default_options`
 		:type options: dict
 		"""
-		if options is None:
-			options = self.default_options
 		self.options = self.default_options.copy()
-		self.options.update(options)
+		if options is not None:
+			self.options.update(options)
 		self.driver = self.options
 		if self.options['debug']:
 			log.setLevel(logging.DEBUG)
 			log.warning('Careful!!\nSetting debug to True, will reveal your password in the log output if you do driver.login()!\nThis is NOT for production!')  # pylint: disable=line-too-long
 		self.client = client_cls(self.options)
-		self._api = {
-			'users': Users(self.client),
-			'teams': Teams(self.client),
-			'channels': Channels(self.client),
-			'posts': Posts(self.client),
-			'files': Files(self.client),
-			'preferences': Preferences(self.client),
-			'status': Status(self.client),
-			'emoji': Emoji(self.client),
-			'reactions': Reactions(self.client),
-			'system': System(self.client),
-			'webhooks': Webhooks(self.client),
-			'commands': Commands(self.client),
-			'compliance': Compliance(self.client),
-			'cluster': Cluster(self.client),
-			'brand': Brand(self.client),
-			'oauth': OAuth(self.client),
-			'roles': Roles(self.client),
-			'saml': SAML(self.client),
-			'ldap': LDAP(self.client),
-			'elasticsearch': Elasticsearch(self.client),
-			'data_retention': DataRetention(self.client),
-			'bots': Bots(self.client),
-			'opengraph': Opengraph(self.client),
-			'integration_actions': IntegrationActions(self.client),
-		}
 		self.websocket = None
-
-	def init_websocket(self, event_handler, websocket_cls=Websocket):
-		"""
-		Will initialize the websocket connection to the mattermost server.
-
-		This should be run after login(), because the websocket needs to make
-		an authentification.
-
-		See https://api.mattermost.com/v4/#tag/WebSocket for which
-		websocket events mattermost sends.
-
-		Example of a really simple event_handler function
-
-		.. code:: python
-
-			async def my_event_handler(message):
-				print(message)
-
-
-		:param event_handler: The function to handle the websocket events. Takes one argument.
-		:type event_handler: Function(message)
-		:return: The event loop
-		"""
-		self.websocket = websocket_cls(self.options, self.client.token)
-		loop = asyncio.get_event_loop()
-		loop.run_until_complete(self.websocket.connect(event_handler))
-		return loop
 
 	def disconnect(self):
 		"""Disconnects the driver from the server, stopping the websocket event loop."""
 		self.websocket.disconnect()
-
-	def login(self):
-		"""
-		Logs the user in.
-
-		The log in information is saved in the client
-			- userid
-			- username
-			- cookies
-
-		:return: The raw response from the request
-		"""
-		if self.options['token']:
-			self.client.token = self.options['token']
-			result = self.users.get_user('me')
-		else:
-			response = self.users.login_user({
-				'login_id': self.options['login_id'],
-				'password': self.options['password'],
-				'token': self.options['mfa_token']
-			})
-			if response.status_code == 200:
-				self.client.token = response.headers['Token']
-				self.client.cookies = response.cookies
-			try:
-				result = response.json()
-			except ValueError:
-				log.debug('Could not convert response to json, returning raw response')
-				result = response
-
-		log.debug(result)
-
-		if 'id' in result:
-			self.client.userid = result['id']
-		if 'username' in result:
-			self.client.username = result['username']
-
-		return result
-
-	def logout(self):
-		"""
-		Log the user out.
-
-		:return: The JSON response from the server
-		"""
-		result = self.users.logout_user()
-		self.client.token = ''
-		self.client.userid = ''
-		self.client.username = ''
-		self.client.cookies = None
-		return result
-
-	@property
-	def api(self):
-		"""
-		.. deprecated:: 4.0.2
-
-		Use the endpoints directly instead.
-
-		:return: dictionary containing the endpoints
-		:rtype: dict
-		"""
-		warnings.warn('Deprecated for 5.0.0. Use the endpoints directly instead.', DeprecationWarning)
-		return self._api
 
 	@property
 	def users(self):
@@ -425,3 +308,171 @@ class Driver:
 		:return: Instance of :class:`~endpoints.integration_actions.IntegrationActions`
 		"""
 		return IntegrationActions(self.client)
+
+
+
+class Driver(BaseDriver):
+	def __init__(self, options=None, client_cls=Client):
+		super().__init__(options, client_cls)
+	
+	def init_websocket(self, event_handler, websocket_cls=Websocket):
+		"""
+		Will initialize the websocket connection to the mattermost server.
+
+		This should be run after login(), because the websocket needs to make
+		an authentification.
+
+		See https://api.mattermost.com/v4/#tag/WebSocket for which
+		websocket events mattermost sends.
+
+		Example of a really simple event_handler function
+
+		.. code:: python
+
+			async def my_event_handler(message):
+				print(message)
+
+
+		:param event_handler: The function to handle the websocket events. Takes one argument.
+		:type event_handler: Function(message)
+		:return: The event loop
+		"""
+		self.websocket = websocket_cls(self.options, self.client.token)
+		loop = asyncio.get_event_loop()
+		loop.run_until_complete(self.websocket.connect(event_handler))
+		return loop
+
+	def login(self):
+		"""
+		Logs the user in.
+
+		The log in information is saved in the client
+			- userid
+			- username
+			- cookies
+
+		:return: The raw response from the request
+		"""
+		if self.options['token']:
+			self.client.token = self.options['token']
+			result = self.users.get_user('me')
+		else:
+			response = self.users.login_user({
+				'login_id': self.options['login_id'],
+				'password': self.options['password'],
+				'token': self.options['mfa_token']
+			})
+			if response.status_code == 200:
+				self.client.token = response.headers['Token']
+				self.client.cookies = response.cookies
+			try:
+				result = response.json()
+			except ValueError:
+				log.debug('Could not convert response to json, returning raw response')
+				result = response
+
+		log.debug(result)
+
+		if 'id' in result:
+			self.client.userid = result['id']
+		if 'username' in result:
+			self.client.username = result['username']
+
+		return result
+
+	def logout(self):
+		"""
+		Log the user out.
+
+		:return: The JSON response from the server
+		"""
+		result = self.users.logout_user()
+		self.client.token = ''
+		self.client.userid = ''
+		self.client.username = ''
+		self.client.cookies = None
+		return result
+
+
+class AsyncDriver(BaseDriver):
+	def __init__(self, options=None, client_cls=AsyncClient):
+		super().__init__(options, client_cls)
+
+	def init_websocket(self, event_handler, websocket_cls=Websocket):
+		"""
+		Will initialize the websocket connection to the mattermost server.
+		unlike the Driver.init_websocket, this one assumes you are async aware
+		and returns a coroutine that can be awaited.  It will not return
+		until shutdown() is called. 
+
+		This should be run after login(), because the websocket needs to make
+		an authentification.
+
+		See https://api.mattermost.com/v4/#tag/WebSocket for which
+		websocket events mattermost sends.
+
+		Example of a really simple event_handler function
+
+		.. code:: python
+
+			async def my_event_handler(message):
+				print(message)
+
+
+		:param event_handler: The function to handle the websocket events. Takes one argument.
+		:type event_handler: Function(message)
+		:return: coroutine 
+		"""
+		self.websocket = websocket_cls(self.options, self.client.token)
+		return self.websocket.connect(event_handler)
+	
+	async def login(self):
+		"""
+		Logs the user in.
+
+		The log in information is saved in the client
+			- userid
+			- username
+			- cookies
+
+		:return: The raw response from the request
+		"""
+		if self.options['token']:
+			self.client.token = self.options['token']
+			result = await self.users.get_user('me')
+		else:
+			response = await self.users.login_user({
+				'login_id': self.options['login_id'],
+				'password': self.options['password'],
+				'token': self.options['mfa_token']
+			})
+			if response.status_code == 200:
+				self.client.token = response.headers['Token']
+				self.client.cookies = response.cookies
+			try:
+				result = response.json()
+			except ValueError:
+				log.debug('Could not convert response to json, returning raw response')
+				result = response
+
+		log.debug(result)
+
+		if 'id' in result:
+			self.client.userid = result['id']
+		if 'username' in result:
+			self.client.username = result['username']
+
+		return result
+
+	async def logout(self):
+		"""
+		Log the user out.
+
+		:return: The JSON response from the server
+		"""
+		result = await self.users.logout_user()
+		self.client.token = ''
+		self.client.userid = ''
+		self.client.username = ''
+		self.client.cookies = None
+		return result

--- a/src/mattermostdriver/exceptions.py
+++ b/src/mattermostdriver/exceptions.py
@@ -1,4 +1,4 @@
-from requests import HTTPError
+from httpx import HTTPError
 
 
 class InvalidOrMissingParameters(HTTPError):


### PR DESCRIPTION
I chose `httpx` because it comes with sync and async interfaces, its close to `requests` api and supports http2. 

The `Driver` and `Client` classes still function the same as they did. 

The new `AsyncDriver` and `AsyncClient` are completely asyncio friendly.   The `AsyncDriver.init__websocket()` no longer does eventloop bootstrapping, and instead leaves it up to the caller who is now assumed to be completely async aware.

A very simple bot using the new interface. 
```
async def event_handler(driver, me, raw):
    payload = json.loads(raw)
    print(payload)
    event = payload.get('event')
    if event:
        data = message.get('data')
        if event == "posted":
            where = data['channel_display_name']
            sender_name = data['sender_name']
            post = json.loads(data['post'])
            msg = post["message"]
            print(f"[{where}] {sender_name}: {msg}")
            id = post['id']
            channel = post['channel_id']
            if me['id'] in data["mentions"]:
                print("they are talking to me!")
                if msg == "die in a fire":
                    await driver.posts.create_post(
                        options={'channel_id': channel, 'message': 'ok, dividing by zero', "root_id": id}
                    )
                    driver.disconnect()
                else:
                    await driver.posts.create_post(
                        options={'channel_id': channel, 'message': 'Got it!', "root_id": id}
                    )
 
async def bot():
    async with AsyncDriver(CONFIG) as driver:
        await driver.login()
        me = await driver.users.get_user('me')
        await driver.init_websocket(partial(event_handler, driver, me))
        await driver.logout()

if __name__ == "__main__":
    asyncio.run(bot())
```