### PR TITLE
fixed file upload - UnicodeDecodeError: 'utf-8' codec can't decode byte in position 342: invalid start byte

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -180,8 +180,8 @@ Usage
     # To upload a file you will need to pass a `files` dictionary
     channel_id = foo.channels.get_channel_by_name_and_team_name('team', 'channel')['id']
     file_id = foo.files.upload_file(
-        channel_id=channel_id
-        files={'files': (filename, open(filename))}
+        channel_id=channel_id,
+        files={'files': (filename, open(filename, 'rb'))}
     )['file_infos'][0]['id']
 
 


### PR DESCRIPTION
I was working last days with Mattermost bot and realised that neither standard upload example and neither `make_request` upload work.

Here is an example how it fails and how it works after this fix:

```
>>> data={'channel_id': '9cygtgktgi8tdcnhct4dk9heto'}
>>> files = {'files': (pdf_name, open(pdf_file))};    file_id_2 = mm.client.make_request('post', '/files', data=data, files=files)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.9/site-packages/mattermostdriver/client.py", line 157, in make_request
    response = request(
  File "/usr/local/lib/python3.9/site-packages/requests/api.py", line 117, in post
    return request('post', url, data=data, json=json, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/requests/api.py", line 61, in request
    return session.request(method=method, url=url, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/requests/sessions.py", line 528, in request
    prep = self.prepare_request(req)
  File "/usr/local/lib/python3.9/site-packages/requests/sessions.py", line 456, in prepare_request
    p.prepare(
  File "/usr/local/lib/python3.9/site-packages/requests/models.py", line 319, in prepare
    self.prepare_body(data, files, json)
  File "/usr/local/lib/python3.9/site-packages/requests/models.py", line 512, in prepare_body
    (body, content_type) = self._encode_files(files, data)
  File "/usr/local/lib/python3.9/site-packages/requests/models.py", line 159, in _encode_files
    fdata = fp.read()
  File "/usr/local/lib/python3.9/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x9c in position 342: invalid start byte
>>>

>>> print(pdf_file)
/app/invoice.pdf
>>>

>>> files = {'files': (pdf_name, open(pdf_file, 'rb'))};    file_id_2 = mm.client.make_request('post', '/files', data=data, files=files);    print(file_id_2.status_code);    print(file_id_2.reason);    print(file_id_2.json)
201
Created
<bound method Response.json of <Response [201]>>
>>>
```