### PR TITLE
Add http proxy support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,15 @@
+Unreleased
+'''''''''''
+
+Added
+- HTTP proxy support for http + websocket calls
+  - Websocket calls are now using aiohttp
+
+7.3.1
+''''''
+
+To be added - Seems missed in the realese?
+
 7.3.0
 ''''''
 Fixed

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
+aiohttp>=3.8.1<4.0.0
 httpx>=0.20.0<1.0.0
-websockets==9.1
 sphinx-rtd-theme==0.4.1

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     packages=find_packages('src'),
     python_requires=">=3.6",
     install_requires=[
-        'websockets>=8',
+        'aiohttp>=3.8.1<4.0.0'
         'httpx>=0.20.0<1.0.0',
     ],
 )

--- a/src/mattermostdriver/client.py
+++ b/src/mattermostdriver/client.py
@@ -35,6 +35,9 @@ class BaseClient:
         self._cookies = None
         self._userid = ""
         self._username = ""
+        self._proxies = None
+        if options["proxy"]:
+            self._proxies = {"all://": options["proxy"]}
 
     @staticmethod
     def _make_url(scheme, url, port, basepath):
@@ -186,7 +189,11 @@ class BaseClient:
 class Client(BaseClient):
     def __init__(self, options):
         super().__init__(options)
-        self.client = httpx.Client(http2=options.get("http2", False), verify=options.get("verify", True))
+        self.client = httpx.Client(
+            http2=options.get("http2", False),
+            proxies=self._proxies,
+            verify=options.get("verify", True),
+        )
 
     def make_request(self, method, endpoint, options=None, params=None, data=None, files=None, basepath=None):
         request, url, request_params = self._build_request(method, options, params, data, files, basepath)
@@ -228,7 +235,11 @@ class Client(BaseClient):
 class AsyncClient(BaseClient):
     def __init__(self, options):
         super().__init__(options)
-        self.client = httpx.AsyncClient(http2=options.get("http2", False), verify=options.get("verify", True))
+        self.client = httpx.AsyncClient(
+            http2=options.get("http2", False),
+            proxies=self._proxies,
+            verify=options.get("verify", True),
+        )
 
     async def __aenter__(self):
         await self.client.__aenter__()

--- a/src/mattermostdriver/driver.py
+++ b/src/mattermostdriver/driver.py
@@ -57,6 +57,7 @@ class BaseDriver:
         "websocket_kw_args": None,
         "debug": False,
         "http2": False,
+        "proxy": None,
     }
     """
 	Required options

--- a/src/mattermostdriver/websocket.py
+++ b/src/mattermostdriver/websocket.py
@@ -86,9 +86,9 @@ class Websocket:
         keep_alive.cancel()
         try:
             await keep_alive
-            await websocket.close()
         except asyncio.CancelledError:
             pass
+        await websocket.close()
 
     async def _do_heartbeats(self, websocket):
         """


### PR DESCRIPTION
Many corporations require the use of a proxy server for logging etc. - We needed this so I added it.

- Add a new 'proxy' option
- Move from websockets to aiohttp due to no http proxy support: https://github.com/aaugustin/websockets/issues/364
- Format 'proxy' option into the dictionary httpx requires for 'all://'
- Updated requirements / setup.py
- Updated CHANGELOG