### PR TITLE
FIX: Removed encode("utf-8") from websocket authentication

### DIFF
--- a/src/mattermostdriver/websocket.py
+++ b/src/mattermostdriver/websocket.py
@@ -117,9 +117,7 @@ class Websocket:
         when connecting to the websocket.
         """
         log.debug("Authenticating websocket")
-        json_data = json.dumps({"seq": 1, "action": "authentication_challenge", "data": {"token": self._token}}).encode(
-            "utf8"
-        )
+        json_data = json.dumps({"seq": 1, "action": "authentication_challenge", "data": {"token": self._token}})
         await websocket.send(json_data)
         while True:
             message = await websocket.recv()


### PR DESCRIPTION
Fixes compatibility with Mattermost 6.3.0

Without this I was getting 1006 error when calling init_websocket after upgrade to mattermost 6.3.0