### PR TITLE
client: connection reuse on 7.x

### DIFF
--- a/src/mattermostdriver/client.py
+++ b/src/mattermostdriver/client.py
@@ -22,6 +22,8 @@ log.setLevel(logging.INFO)
 
 # pylint: disable=too-many-instance-attributes
 class Client:
+	requests = requests.Session()
+
 	def __init__(self, options):
 		self._url = '{scheme:s}://{url:s}:{port:d}{basepath:s}'.format(
 			scheme=options['scheme'],
@@ -133,13 +135,13 @@ class Client:
 		else:
 			url = self.url
 		method = method.lower()
-		request = requests.get
+		request = self.requests.get
 		if method == 'post':
-			request = requests.post
+			request = self.requests.post
 		elif method == 'put':
-			request = requests.put
+			request = self.requests.put
 		elif method == 'delete':
-			request = requests.delete
+			request = self.requests.delete
 
 		request_params = {
 			'headers': self.auth_header(),


### PR DESCRIPTION
Hi,
I noticed you moved away from `requests` for your next major release, however I would still like to suggest an improvement against the 7.x series by adding connection reuse on the Clients...

Cheers.