### PR TITLE
PROTOCOL_TLS_SERVER context fix

### DIFF
--- a/src/mattermostdriver/websocket.py
+++ b/src/mattermostdriver/websocket.py
@@ -29,7 +29,7 @@ class Websocket:
         :type event_handler: Function(message)
         :return:
         """
-        context = ssl.create_default_context(purpose=ssl.Purpose.CLIENT_AUTH)
+        context = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH)
         if not self.options["verify"]:
             context.verify_mode = ssl.CERT_NONE
 


### PR DESCRIPTION
Hi! The PR fix this error:

`Cannot create a client socket with a PROTOCOL_TLS_SERVER context (_ssl.c:801)`

It happens, when setting default ssl context in this line:
https://github.com/Vaelor/python-mattermost-driver/blob/1c70fd1e7ef4083ecf6316adc82c4739c4b2526c/src/mattermostdriver/websocket.py#L32

In documentation says, that `CLIENT_AUTH` is used when creates server-side socket.
ref: https://docs.python.org/3/library/ssl.html#ssl.Purpose.CLIENT_AUTH

Since is creating a socket to connect **to the server**, need to use `SERVER_AUTH`.
ref: https://docs.python.org/3/library/ssl.html#ssl.Purpose.SERVER_AUTH

I know you don't have much time so I thought this PR would make your life a little easier :)

If this bug is already fixed, please reject it or I can remove the PR myself.