### PR TITLE
Fix setup.py for pip install python3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     packages=find_packages('src'),
     python_requires=">=3.6",
     install_requires=[
-        'aiohttp>=3.8.1,<4.0.0'
+        'aiohttp>=3.8.1,<4.0.0',
         'httpx>=0.20.0,<1.0.0',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     packages=find_packages('src'),
     python_requires=">=3.6",
     install_requires=[
-        'aiohttp>=3.8.1<4.0.0'
-        'httpx>=0.20.0<1.0.0',
+        'aiohttp>=3.8.1,<4.0.0'
+        'httpx>=0.20.0,<1.0.0',
     ],
 )


### PR DESCRIPTION
pip install from source is currently broken. 
```
pip install git+https://github.com/Vaelor/python-mattermost-driver.git
Looking in indexes: https://artifactory.teslamotors.com/artifactory/api/pypi/autopilot-release-pypi/simple, https://artifactory.dev.teslamotors.com/artifactory/api/pypi/autopilot-release-local/simple, https://pypi.teslamotors.com/simple
Collecting git+https://github.com/Vaelor/python-mattermost-driver.git
  Cloning https://github.com/Vaelor/python-mattermost-driver.git to /tmp/pip-req-build-kibg6v46
  Running command git clone --filter=blob:none --quiet https://github.com/Vaelor/python-mattermost-driver.git /tmp/pip-req-build-kibg6v46
  Resolved https://github.com/Vaelor/python-mattermost-driver.git to commit c6ac437d351c32ea7bf1eca39846a6482c51bd01
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [3 lines of output]
      error in mattermostdriver setup command: 'install_requires' must be a string or iterable of strings containing valid project/version requirement specifiers; Expected end or semicolon (after version specifier)
          aiohttp>=3.8.1<4.0.0httpx>=0.20.0<1.0.0
                 ~~~~~~~^
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error
```